### PR TITLE
Update grammar matcher for newer Atom editor

### DIFF
--- a/snippets/contrib.cson
+++ b/snippets/contrib.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'hook_libraries_info':
     'prefix': 'h.libraries_info'
     'body': '''

--- a/snippets/core.cson
+++ b/snippets/core.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'aggregator_admin_form':
     'prefix': 'aggregator_admin_form'
     'body': '''aggregator_admin_form(${1:form}, ${2:form_state})'''

--- a/snippets/devel.cson
+++ b/snippets/devel.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'dd':
     'prefix': 'dd'
     'body': '''dd($1);'''

--- a/snippets/efq.cson
+++ b/snippets/efq.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'entityCondition':
     'prefix': 'entityCondition'
     'body': '''entityCondition(${1:name}, ${2:value}${3:, ${4:operator}})${5:;}'''

--- a/snippets/fapi.cson
+++ b/snippets/fapi.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'fapi.fieldset':
     'prefix': 'fapi.fieldset'
     'body': '''

--- a/snippets/file.cson
+++ b/snippets/file.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'drupal_basename':
     'prefix': 'drupal_basename'
     'body': '''drupal_basename(${1:uri}${2:, ${3:suffix}})'''

--- a/snippets/migrate.cson
+++ b/snippets/migrate.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'migration':
     'prefix': 'migration'
     'body': '''

--- a/snippets/query.cson
+++ b/snippets/query.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'qcon':
     'prefix': 'qcon'
     'body': '''\$${1:query}->condition(${2:'${3:field}'}, ${4:'${5:value}'}, '${6:=}')${7:;}'''

--- a/snippets/simpletest.cson
+++ b/snippets/simpletest.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'DrupalUnitTestCase':
     'prefix': 'DrupalUnitTestCase'
     'body': '''

--- a/snippets/snippets.cson
+++ b/snippets/snippets.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'block':
     'prefix': 'block'
     'body': '''

--- a/snippets/themes.cson
+++ b/snippets/themes.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'pre_admin_block':
     'prefix': 'pre_admin_block'
     'body': '''/**

--- a/snippets/views.cson
+++ b/snippets/views.cson
@@ -1,4 +1,4 @@
-'.source.php':
+'.text.html.php':
   'aggregator_views_api':
     'prefix': 'aggregator_views_api'
     'body': '''aggregator_views_api()'''


### PR DESCRIPTION
The snippets weren't working since PHP is now `text.html.php`. I made the change and bumped the version to 2.0.0.